### PR TITLE
Fix zscan and hscan overrides

### DIFF
--- a/src/Connections/PhpRedisSentinelConnection.php
+++ b/src/Connections/PhpRedisSentinelConnection.php
@@ -41,7 +41,7 @@ class PhpRedisSentinelConnection extends PhpRedisConnection
     public function zscan($key, $cursor, $options = []): mixed
     {
         try {
-            return parent::sscan($key, $cursor, $options);
+            return parent::zscan($key, $cursor, $options);
         } catch (RedisException $e) {
             $this->reconnectIfRedisIsUnavailableOrReadonly($e);
 
@@ -57,7 +57,7 @@ class PhpRedisSentinelConnection extends PhpRedisConnection
     public function hscan($key, $cursor, $options = []): mixed
     {
         try {
-            return parent::sscan($key, $cursor, $options);
+            return parent::hscan($key, $cursor, $options);
         } catch (RedisException $e) {
             $this->reconnectIfRedisIsUnavailableOrReadonly($e);
 


### PR DESCRIPTION
Due to a copy and paste error, the wrong method has been invoked by the overrides.