### PR TITLE
Run CI tests against PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
         uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1']
+        php-version: ['8.0', '8.1', '8.2']
         include:
           - operating-system: 'ubuntu-latest'
-            php-version: '8.1'
+            php-version: '8.2'
             run-sonarqube-analysis: true
 
     services:


### PR DESCRIPTION
Currently, the tests are run against PHP `8.0` and `8.1`. This PR adds test runs for PHP `8.2`, as it is supported by the `composer.json` constraint `php:^8.0`.