### PR TITLE
Add support for Laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /vendor
 .idea
 .php-cs-fixer.cache
+.phpunit.cache
 .phpunit.result.cache
 composer.lock
 phpunit.coverage*.xml

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "require": {
         "php": "^8.0",
         "ext-redis": "*",
-        "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/redis": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "illuminate/redis": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^6.0|^7.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0"
     },
     "scripts": {
         "test": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    backupStaticProperties="false"
+    cacheDirectory=".phpunit.cache"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,7 @@
     </php>
     <testsuites>
         <testsuite name="Test">
-            <directory suffix=".php">tests</directory>
+            <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
     <coverage>


### PR DESCRIPTION
This PR adds support for Laravel 10. No noticeable changes are required. The `phpunit.xml` format has been migrated to the new schema.