### PR TITLE
Add support for PhpRedis 6.0

### DIFF
--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -92,27 +92,20 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
         }
 
         if (version_compare(phpversion('redis'), '6.0', '>=')) {
-            if (strlen(trim($password)) !== 0) {
-                /** @noinspection PhpMethodParametersCountMismatchInspection */
-                return new RedisSentinel([
-                    'host' => $host,
-                    'port' => $port,
-                    'connectTimeout' => $timeout,
-                    'persistent' => $persistent,
-                    'retryInterval' => $retryInterval,
-                    'readTimeout' => $readTimeout,
-                    'auth' => $password,
-                ]);
-            }
-
-            return new RedisSentinel([
+            $options = [
                 'host' => $host,
                 'port' => $port,
                 'connectTimeout' => $timeout,
                 'persistent' => $persistent,
                 'retryInterval' => $retryInterval,
                 'readTimeout' => $readTimeout,
-            ]);
+            ];
+
+            if (strlen(trim($password)) !== 0) {
+                $options['auth'] = $password;
+            }
+
+            return new RedisSentinel($options);
         } else {
             if (strlen(trim($password)) !== 0) {
                 /** @noinspection PhpMethodParametersCountMismatchInspection */

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -91,8 +91,20 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
             throw new ConfigurationException('No host has been specified for the Redis Sentinel connection.');
         }
 
-        if (strlen(trim($password)) !== 0) {
-            /** @noinspection PhpMethodParametersCountMismatchInspection */
+        if (version_compare(phpversion('redis'), '6.0', '>=')) {
+            if (strlen(trim($password)) !== 0) {
+                /** @noinspection PhpMethodParametersCountMismatchInspection */
+                return new RedisSentinel([
+                    'host' => $host,
+                    'port' => $port,
+                    'connectTimeout' => $timeout,
+                    'persistent' => $persistent,
+                    'retryInterval' => $retryInterval,
+                    'readTimeout' => $readTimeout,
+                    'auth' => $password,
+                ]);
+            }
+
             return new RedisSentinel([
                 'host' => $host,
                 'port' => $port,
@@ -100,17 +112,14 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
                 'persistent' => $persistent,
                 'retryInterval' => $retryInterval,
                 'readTimeout' => $readTimeout,
-                'auth' => $password,
             ]);
-        }
+        } else {
+            if (strlen(trim($password)) !== 0) {
+                /** @noinspection PhpMethodParametersCountMismatchInspection */
+                return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $password);
+            }
 
-        return new RedisSentinel([
-            'host' => $host,
-            'port' => $port,
-            'connectTimeout' => $timeout,
-            'persistent' => $persistent,
-            'retryInterval' => $retryInterval,
-            'readTimeout' => $readTimeout,
-        ]);
+            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout);
+        }
     }
 }

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -93,9 +93,24 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
 
         if (strlen(trim($password)) !== 0) {
             /** @noinspection PhpMethodParametersCountMismatchInspection */
-            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $password);
+            return new RedisSentinel([
+                'host' => $host,
+                'port' => $port,
+                'connectTimeout' => $timeout,
+                'persistent' => $persistent,
+                'retryInterval' => $retryInterval,
+                'readTimeout' => $readTimeout,
+                'auth' => $password,
+            ]);
         }
 
-        return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout);
+        return new RedisSentinel([
+            'host' => $host,
+            'port' => $port,
+            'connectTimeout' => $timeout,
+            'persistent' => $persistent,
+            'retryInterval' => $retryInterval,
+            'readTimeout' => $readTimeout,
+        ]);
     }
 }


### PR DESCRIPTION
PhpRedis 6.0 changes the RedisSentinel constructor. This PR changes how configuration is passed to constructor for PhpRedis 6.0. See: https://github.com/phpredis/phpredis/commit/ebb2386e52c9ddd8a45e3cd67f12d77be894e1d7#diff-a1471159ac00556a439382b010c89a8507ebc6f03311ec7655cebd95dc6c978e