### PR TITLE
Add ability to auth with username + password to sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To use the Redis Sentinel driver, the `redis` section in `config/database.php` n
         'sentinel_persistent' => env('REDIS_SENTINEL_PERSISTENT'),
         'sentinel_retry_interval' => env('REDIS_SENTINEL_RETRY_INTERVAL', 0),
         'sentinel_read_timeout' => env('REDIS_SENTINEL_READ_TIMEOUT', 0),
+        'sentinel_username' => env('REDIS_SENTINEL_USERNAME'),
         'sentinel_password' => env('REDIS_SENTINEL_PASSWORD'),
         'password' => env('REDIS_PASSWORD'),
         'database' => env('REDIS_DB', 0),

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -104,15 +104,20 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
         }
 
         if (version_compare(phpversion('redis'), '6.0', '>=')) {
-            return new RedisSentinel([
+            $options = [
                 'host' => $host,
                 'port' => $port,
                 'connectTimeout' => $timeout,
                 'persistent' => $persistent,
                 'retryInterval' => $retryInterval,
                 'readTimeout' => $readTimeout,
-                'auth' => $auth,
-            ]);
+            ];
+
+            if ($auth !== null) {
+                $options['auth'] = $auth;
+            }
+            
+            return new RedisSentinel($options);
         }
 
         /** @noinspection PhpMethodParametersCountMismatchInspection */

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -89,6 +89,7 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
         $persistent = $config['sentinel_persistent'] ?? null;
         $retryInterval = $config['sentinel_retry_interval'] ?? 0;
         $readTimeout = $config['sentinel_read_timeout'] ?? 0;
+        $username = $config['sentinel_username'] ?? '';
         $password = $config['sentinel_password'] ?? '';
 
         if (strlen(trim($host)) === 0) {
@@ -105,18 +106,24 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
                 'readTimeout' => $readTimeout,
             ];
 
-            if (strlen(trim($password)) !== 0) {
+            if (strlen(trim($password)) !== 0 && strlen(trim($username)) !== 0) {
+                $options['auth'] = [$username, $password];
+            } elseif (strlen(trim($password)) !== 0) {
                 $options['auth'] = $password;
             }
 
             return new RedisSentinel($options);
         } else {
-            if (strlen(trim($password)) !== 0) {
-                /** @noinspection PhpMethodParametersCountMismatchInspection */
-                return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $password);
+            $auth = null;
+            if (strlen(trim($password)) !== 0 && strlen(trim($username)) !== 0) {
+                $auth = [$username, $password];
+            }
+            elseif (strlen(trim($password)) !== 0) {
+                $auth = $password;
             }
 
-            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout);
+            /** @noinspection PhpMethodParametersCountMismatchInspection */
+            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $auth);
         }
     }
 }

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -96,33 +96,26 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
             throw new ConfigurationException('No host has been specified for the Redis Sentinel connection.');
         }
 
+        $auth = null;
+        if (strlen(trim($username)) !== 0 && strlen(trim($password)) !== 0) {
+            $auth = [$username, $password];
+        } elseif (strlen(trim($password)) !== 0) {
+            $auth = $password;
+        }
+
         if (version_compare(phpversion('redis'), '6.0', '>=')) {
-            $options = [
+            return new RedisSentinel([
                 'host' => $host,
                 'port' => $port,
                 'connectTimeout' => $timeout,
                 'persistent' => $persistent,
                 'retryInterval' => $retryInterval,
                 'readTimeout' => $readTimeout,
-            ];
-
-            if (strlen(trim($password)) !== 0 && strlen(trim($username)) !== 0) {
-                $options['auth'] = [$username, $password];
-            } elseif (strlen(trim($password)) !== 0) {
-                $options['auth'] = $password;
-            }
-
-            return new RedisSentinel($options);
-        } else {
-            $auth = null;
-            if (strlen(trim($password)) !== 0 && strlen(trim($username)) !== 0) {
-                $auth = [$username, $password];
-            } elseif (strlen(trim($password)) !== 0) {
-                $auth = $password;
-            }
-
-            /** @noinspection PhpMethodParametersCountMismatchInspection */
-            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $auth);
+                'auth' => $auth,
+            ]);
         }
+
+        /** @noinspection PhpMethodParametersCountMismatchInspection */
+        return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $auth);
     }
 }

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -117,8 +117,7 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
             $auth = null;
             if (strlen(trim($password)) !== 0 && strlen(trim($username)) !== 0) {
                 $auth = [$username, $password];
-            }
-            elseif (strlen(trim($password)) !== 0) {
+            } elseif (strlen(trim($password)) !== 0) {
                 $auth = $password;
             }
 

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -116,7 +116,7 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
             if ($auth !== null) {
                 $options['auth'] = $auth;
             }
-            
+
             return new RedisSentinel($options);
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,6 +41,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('database.redis.default', [
             'sentinel_host' => env('REDIS_SENTINEL_HOST', '127.0.0.1'),
             'sentinel_port' => (int) env('REDIS_SENTINEL_PORT', 6379),
+            'sentinel_username' => env('REDIS_SENTINEL_USERNAME'),
             'sentinel_password' => env('REDIS_SENTINEL_PASSWORD'),
             'sentinel_service' => env('REDIS_SENTINEL_SERVICE', 'mymaster'),
         ]);


### PR DESCRIPTION
Added REDIS_SENTINEL_USERNAME to allow authentication with username + password combo.

Auth parameter from sentinel documentation (https://github.com/phpredis/phpredis/blob/develop/sentinel.md): 

"auth:String, or an Array with one or two elements, used to authenticate with the redis-sentinel. (optional, default is NULL meaning NOAUTH)"