### PR TITLE
Call RedisSentinel constructor with auth arg only if set

### DIFF
--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -120,7 +120,11 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
             return new RedisSentinel($options);
         }
 
-        /** @noinspection PhpMethodParametersCountMismatchInspection */
-        return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $auth);
+        if ($auth !== null) {
+            /** @noinspection PhpMethodParametersCountMismatchInspection */
+            return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout, $auth);
+        }
+
+        return new RedisSentinel($host, $port, $timeout, $persistent, $retryInterval, $readTimeout);
     }
 }


### PR DESCRIPTION
According to #26, the `RedisSentinel` constructor seems to not allow passing `null` as `auth` parameter. The [documentation regarding this parameter](https://github.com/phpredis/phpredis/blob/release/5.3.6/sentinel.markdown) is somewhat vague regarding the allowed values to be passed. It only says that the default is `null` if nothing is passed.