### PR TITLE
Build PHP 8.3 & drop support for PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,15 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3']
         include:
           - operating-system: 'ubuntu-latest'
-            php-version: '8.2'
+            php-version: '8.3'
             run-sonarqube-analysis: true
 
     services:
       redis:
-        image: bitnami/redis:6.2.4-debian-10-r35
+        image: bitnami/redis:7.4-debian-12
         ports:
           - 6379:6379
         env:
@@ -36,7 +36,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis-sentinel:
-        image: bitnami/redis-sentinel:6.2.4-debian-10-r39
+        image: bitnami/redis-sentinel:7.4-debian-12
         ports:
           - 26379:26379
         env:
@@ -60,7 +60,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: redis
-          tools: phpunit:9.5.0
           coverage: pcov
 
       - name: Setup problem matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-redis": "*",
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0",
         "illuminate/redis": "^8.0|^9.0|^10.0|^11.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,6 @@
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         shortenArraysForExportThreshold="10"
          requireCoverageMetadata="false"
          beStrictAboutCoverageMetadata="true"
          beStrictAboutOutputDuringTests="true"
@@ -23,7 +22,7 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+    <source restrictNotices="true" restrictWarnings="true">
         <include>
             <directory>src</directory>
         </include>


### PR DESCRIPTION
Since PHP 8.0 is end of life, we drop support for it. At the same time, we start building against PHP 8.3. Small changes to the phpunit config are required to make multiple versions of phpunit work.