### PR TITLE
Add support for SSL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ Noteworthy is the `sentinel_service`, which represents the instance name of the 
 
 All other options are the same for the Redis Sentinel driver, except that `url` is not supported and `host` and `port` are ignored.
 
+### SSL Support
+
+If you want to use SSL to connect to Redis Sentinel, you need to add an additional configuration option 'sentinel_ssl' next to the other 'sentinel_*' settings:
+
+```php
+'sentinel_ssl' => [
+    // ... ssl settings ...
+],
+```
+
+Available SSL context options can be found in the [official PHP documentation](https://www.php.net/manual/en/context.ssl.php).
+
+NOTE: The SSL options only work for the `phpredis` extension starting from version 6.1.0.
+
 ### How does it work?
 
 An additional Laravel Redis driver is added (`phpredis-sentinel`), which resolves the currently declared master instance of a replication

--- a/src/Connectors/PhpRedisSentinelConnector.php
+++ b/src/Connectors/PhpRedisSentinelConnector.php
@@ -91,6 +91,7 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
         $readTimeout = $config['sentinel_read_timeout'] ?? 0;
         $username = $config['sentinel_username'] ?? '';
         $password = $config['sentinel_password'] ?? '';
+        $ssl = $config['sentinel_ssl'] ?? null;
 
         if (strlen(trim($host)) === 0) {
             throw new ConfigurationException('No host has been specified for the Redis Sentinel connection.');
@@ -115,6 +116,10 @@ class PhpRedisSentinelConnector extends PhpRedisConnector
 
             if ($auth !== null) {
                 $options['auth'] = $auth;
+            }
+
+            if (version_compare(phpversion('redis'), '6.1', '>=') && $ssl !== null) {
+                $options['ssl'] = $ssl;
             }
 
             return new RedisSentinel($options);


### PR DESCRIPTION
This PR adds support for SSL connections to Redis Sentinel (requires `phpredis` extension version `>=6.1`). As part of this addition, details regarding the SSL configuration of Redis itself have also been added.

Fixes #35