### PR TITLE
Fix: use explicit nullable type in method declaration

### DIFF
--- a/src/Connections/PhpRedisSentinelConnection.php
+++ b/src/Connections/PhpRedisSentinelConnection.php
@@ -103,7 +103,7 @@ class PhpRedisSentinelConnection extends PhpRedisConnection
      *
      * @throws RedisException
      */
-    public function pipeline(callable $callback = null): Redis|array
+    public function pipeline(?callable $callback = null): Redis|array
     {
         try {
             return parent::pipeline($callback);
@@ -119,7 +119,7 @@ class PhpRedisSentinelConnection extends PhpRedisConnection
      *
      * @throws RedisException
      */
-    public function transaction(callable $callback = null): Redis|array
+    public function transaction(?callable $callback = null): Redis|array
     {
         try {
             return parent::transaction($callback);


### PR DESCRIPTION
As mentioned in #45, implicit nullable types throw a deprecation warning starting in PHP 8.4. The required change is to use the explicit nullable type.