### PR TITLE
Add connection timed out to error messages list

### DIFF
--- a/src/Services/RetryManager.php
+++ b/src/Services/RetryManager.php
@@ -27,6 +27,7 @@ class RetryManager
         'loading',
         'readonly',
         "can't write against a read only replica",
+        "connection timed out"
     ];
 
     /**


### PR DESCRIPTION
Hi,

We are hitting an error with our system and randomly we get the "connection timed out" error from Redis. Since this is not in the array, the system is not retrying. Upon adding it to the array, it will be retried and things appear to be working nicely with the retry. 

Thanks!

-Rob